### PR TITLE
COMP: Use https protocol for git by default

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -4,11 +4,10 @@ slicer_check_cmake_https()
 #-----------------------------------------------------------------------------
 # Git protocol option
 #-----------------------------------------------------------------------------
-option(${CMAKE_PROJECT_NAME}_USE_GIT_PROTOCOL "If behind a firewall turn this off to use http instead." ON)
-
-set(git_protocol "git")
-if(NOT ${CMAKE_PROJECT_NAME}_USE_GIT_PROTOCOL)
-  set(git_protocol "http")
+option(${CMAKE_PROJECT_NAME}_USE_GIT_PROTOCOL "Turn off if using GitHub or behind a firewall." OFF)
+set(git_protocol "https")
+if(${CMAKE_PROJECT_NAME}_USE_GIT_PROTOCOL)
+  set(git_protocol "git")
 endif()
 
 #-----------------------------------------------------------------------------

--- a/SuperBuild/External_python-pyradiomics.cmake
+++ b/SuperBuild/External_python-pyradiomics.cmake
@@ -20,7 +20,7 @@ endif()
 if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   if(NOT DEFINED git_protocol)
-    set(git_protocol "git")
+    set(git_protocol "https")
   endif()
 
   ExternalProject_SetIfNotDefined(


### PR DESCRIPTION
This PR aims to solve current SlicerRadiomics build issue https://slicer.cdash.org/viewBuildError.php?buildid=2628696.

GitHub has disabled the unauthenticated git protocol by default
(see https://github.blog/2021-09-01-improving-git-protocol-security-github).

Since most projects are hosted on GitHub, disable git protocol by default (and use https instead).

This is based on corresponding Slicer commit https://github.com/Slicer/Slicer/commit/99578c69edb147c9d0b517270803e30851fa7660.

cc: @JoostJM or @fedorov for review.